### PR TITLE
oikeuskäytännön lataus tietokantaan

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -166,8 +166,7 @@ app.get('/api/judgment/keyword/:keyword/:language', async (request: express.Requ
     return {
       docYear: result.year,
       docNumber: result.number,
-      docLevel: result.level,
-      docTitle: result.title
+      docLevel: result.level
     }
   })
   response.json(preparedResults)

--- a/backend/src/db/akoma.ts
+++ b/backend/src/db/akoma.ts
@@ -61,4 +61,16 @@ async function getLatestYearLaw() : Promise<number> {
   return parseInt(result.rows[0].latest_year, 10);
 }
 
-export { setJudgment, getLawByNumberYear, getLawsByYear, getLawsByContent, setLaw, getLawCountByYear, getLatestYearLaw, getJudgmentByNumberYear, getJudgmentsByYear, getJudgmentsByContent };
+async function getJudgmentCountByYear(year: number): Promise<number> {
+  const sql = 'SELECT COUNT(*) FROM judgments where year = $1';
+  const result = await query(sql, [year]);
+  return parseInt(result.rows[0].count, 10);
+}
+
+async function getLatestYearJudgment() : Promise<number> {
+  const sql = 'SELECT MAX(year) AS latest_year FROM judgments';
+  const result = await query(sql);
+  return parseInt(result.rows[0].latest_year, 10);
+}
+
+export { setJudgment, getLawByNumberYear, getLawsByYear, getLawsByContent, setLaw, getLawCountByYear, getLatestYearLaw, getJudgmentByNumberYear, getJudgmentsByYear, getJudgmentsByContent, getJudgmentCountByYear, getLatestYearJudgment };

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -57,7 +57,7 @@ async function dbIsReady(): Promise<boolean> {
     const lawsCount = parseInt(result.rows[0].count, 10);
     result = await client.query("SELECT COUNT(*) FROM judgements;");
     const judgmentsCount = parseInt(result.rows[0].count, 10);
-    
+
     return imagesCount > 0 && lawsCount > 0 && judgmentsCount > 0;
   } catch (error) {
     console.error('Error checking database readiness:', error);

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -44,15 +44,21 @@ async function dbIsReady(): Promise<boolean> {
 
     result = await client.query("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'laws');")
     const lawsExists = result.rows[0].exists;
+
+    result = await client.query("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'judgments');")
+    const judgmentsExists = result.rows[0].exists;
     client.release();
-    if  (!imagesExists || !lawsExists) {
+    if  (!imagesExists || !lawsExists || !judgmentsExists) {
       return false
     }
     result = await client.query("SELECT COUNT(*) FROM images;");
     const imagesCount = parseInt(result.rows[0].count, 10);
     result = await client.query("SELECT COUNT(*) FROM laws;");
     const lawsCount = parseInt(result.rows[0].count, 10);
-    return imagesCount > 0 && lawsCount > 0;
+    result = await client.query("SELECT COUNT(*) FROM judgements;");
+    const judgmentsCount = parseInt(result.rows[0].count, 10);
+    
+    return imagesCount > 0 && lawsCount > 0 && judgmentsCount > 0;
   } catch (error) {
     console.error('Error checking database readiness:', error);
     throw error;

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -1,7 +1,7 @@
 
 import { Pool, QueryResult } from 'pg';
-import { setStatutesByYear, setJudgmentsByYear } from './load.js';
-import { getLatestYearLaw, getLawCountByYear, getLawsByYear } from './akoma.js';
+import { setStatutesByYear, setJudgmentsByYear, listStatutesByYear, listJudgmentsByYear } from './load.js';
+import { getLatestYearLaw, getLawCountByYear, getLatestYearJudgment, getJudgmentCountByYear } from './akoma.js';
 
 let pool: Pool;
 
@@ -11,23 +11,19 @@ async function setPool(uri: string) {
   });
 }
 
-async function fillDb(startYear: number = 1900): Promise<void> {
+async function fillDb(startYearLaw: number = 1900, startYearJudgment: number = 1900): Promise<void> {
   try {
     const currentYear = new Date().getFullYear();
-    for (let i = startYear; i <= currentYear; i++) {
+    for (let i = startYearLaw; i <= currentYear; i++) {
       await setStatutesByYear(i, 'fin')
       await setStatutesByYear(i, 'swe')
+    }
+
+    for (let i = startYearJudgment; i <= currentYear; i++) {
       await setJudgmentsByYear(i, 'fin', 'kho')
       await setJudgmentsByYear(i, 'fin', 'kko')
       await setJudgmentsByYear(i, 'swe', 'kho')
       await setJudgmentsByYear(i, 'swe', 'kko')
-    }
-    for (const i of [1898, 1896, 1895, 1894, 1893, 1892, 1889, 1886, 1883, 1873, 1872, 1868, 1864, 1734]) {
-      if (i < startYear) {
-        continue;
-      }
-      await setStatutesByYear(i, 'fin')
-      await setStatutesByYear(i, 'swe')
     }
     console.log("Database is filled")
   } catch (error) {
@@ -48,38 +44,55 @@ async function dbIsReady(): Promise<boolean> {
     result = await client.query("SELECT EXISTS (SELECT 1 FROM information_schema.tables WHERE table_schema = 'public' AND table_name = 'judgments');")
     const judgmentsExists = result.rows[0].exists;
     client.release();
-    if  (!imagesExists || !lawsExists || !judgmentsExists) {
-      return false
-    }
-    result = await client.query("SELECT COUNT(*) FROM images;");
-    const imagesCount = parseInt(result.rows[0].count, 10);
-    result = await client.query("SELECT COUNT(*) FROM laws;");
-    const lawsCount = parseInt(result.rows[0].count, 10);
-    result = await client.query("SELECT COUNT(*) FROM judgments;");
-    const judgmentsCount = parseInt(result.rows[0].count, 10);
+    return imagesExists && lawsExists && judgmentsExists
 
-    return imagesCount > 0 && lawsCount > 0 && judgmentsCount > 0;
+
   } catch (error) {
     console.error('Error checking database readiness:', error);
     throw error;
   }
 }
 
-async function dbIsUpToDate(): Promise<{upToDate: boolean, latestYear: number}> {
+async function dbIsUpToDate(): Promise<{upToDate: boolean, latestYearLaw: number, latestYearJudgment: number}> {
   try {
-    const latestYear = await getLatestYearLaw();
     const currentYear = new Date().getFullYear();
-    if (latestYear == currentYear) {
+    let latestYearLaw = await getLatestYearLaw();
+    let latestYearJudgment = await getLatestYearJudgment(); // Assuming this function also works for judgments
+    let upToDate = true;
+
+    if (latestYearLaw == currentYear) {
       const numberOfLaws = await getLawCountByYear(currentYear);
-      const expectedFin = await getLawsByYear(currentYear, 'fin');
-      const expectedSwe = await getLawsByYear(currentYear, 'swe');
+      const expectedFin = await listStatutesByYear(currentYear, 'fin');
+      const expectedSwe = await listStatutesByYear(currentYear, 'swe');
       const exprectedNumberOfLaws = expectedFin.length + expectedSwe.length;
       if (numberOfLaws != exprectedNumberOfLaws) {
-        return { upToDate: false, latestYear };
+        console.log(`Number of laws for year ${currentYear} does not match expected: ${numberOfLaws} vs ${exprectedNumberOfLaws}`);
+        upToDate = false;
       } else {
-        return { upToDate: true, latestYear };
+        ++latestYearLaw
       }
-    } else { return { upToDate: false, latestYear };}
+    } else {
+      upToDate = false;
+    }
+
+    if (latestYearJudgment == currentYear) {
+      const numberOfJudgments = await getJudgmentCountByYear(currentYear);
+      const expectedFinKKO = await listJudgmentsByYear(currentYear, 'fin', 'kko');
+      const expectedSweKKO = await listJudgmentsByYear(currentYear, 'swe', 'kko');
+      const expectedFinKHO = await listJudgmentsByYear(currentYear, 'fin', 'kho');
+      const expectedSweKHO = await listJudgmentsByYear(currentYear, 'swe', 'kho');
+      const exprectedNumberOfJudgments = expectedFinKKO.length + expectedSweKKO.length + expectedFinKHO.length + expectedSweKHO.length;
+      if (numberOfJudgments != exprectedNumberOfJudgments) {
+        console.log(`Number of judgments for year ${currentYear} does not match expected: ${numberOfJudgments} vs ${exprectedNumberOfJudgments}`);
+        upToDate = false;
+      } else {
+        ++latestYearJudgment
+      }
+    } else {
+      upToDate = false;
+    }
+    console.log(`Database up to date: ${upToDate}, Latest law year: ${latestYearLaw}, Latest judgment year: ${latestYearJudgment}`);
+    return { upToDate, latestYearLaw, latestYearJudgment };
   } catch (error) {
     console.error('Error checking if database is up to date:', error);
     throw error;

--- a/backend/src/db/db.ts
+++ b/backend/src/db/db.ts
@@ -55,7 +55,7 @@ async function dbIsReady(): Promise<boolean> {
     const imagesCount = parseInt(result.rows[0].count, 10);
     result = await client.query("SELECT COUNT(*) FROM laws;");
     const lawsCount = parseInt(result.rows[0].count, 10);
-    result = await client.query("SELECT COUNT(*) FROM judgements;");
+    result = await client.query("SELECT COUNT(*) FROM judgments;");
     const judgmentsCount = parseInt(result.rows[0].count, 10);
 
     return imagesCount > 0 && lawsCount > 0 && judgmentsCount > 0;

--- a/backend/src/db/load.ts
+++ b/backend/src/db/load.ts
@@ -308,6 +308,7 @@ async function listJudgmentsByYear(year: number, language: string, level: string
 }
 
 
+
 async function setStatutesByYear(year: number, language: string) {
   const uris = await listStatutesByYear(year, language)
   for (const uri of uris) {
@@ -324,4 +325,4 @@ async function setJudgmentsByYear(year: number, language: string, level: string)
   console.log(`Set ${uris.length} judgment for year ${year} in language ${language} and level ${level}`)
 }
 
-export { listStatutesByYear, setJudgmentsByYear, setStatutesByYear, setSingleStatute, listJudgmentNumbersByYear, parseURLfromJudgmentID, setSingleJudgment, parseAkomafromURL }
+export { listStatutesByYear, setJudgmentsByYear, setStatutesByYear, setSingleStatute, listJudgmentNumbersByYear, listJudgmentsByYear, parseURLfromJudgmentID, setSingleJudgment, parseAkomafromURL }

--- a/backend/src/db/load.ts
+++ b/backend/src/db/load.ts
@@ -306,7 +306,7 @@ async function listJudgmentNumbersByYear(year: number, language: string, level: 
     });
     const inputHTML = result.data as string;
     parsedList = parseJudgmentList(inputHTML, language, level);
-  } catch (error) {
+  } catch {
     console.error(`Failed to fetch judgment numbers for year ${year}, language ${language}, level ${level}`);
     return [];
   }

--- a/backend/src/index.ts
+++ b/backend/src/index.ts
@@ -36,10 +36,10 @@ async function initDatabase() {
       console.log('Database is ready.')
     } else {
       console.log('Database is ready.')
-      const { upToDate, latestYear } = await dbIsUpToDate()
+      const { upToDate, latestYearLaw, latestYearJudgment } = await dbIsUpToDate()
       if (!upToDate) {
         console.log('Database is not up to date, filling database...')
-        await fillDb(latestYear)
+        await fillDb(latestYearLaw, latestYearJudgment)
         console.log('Database is now up to date.')
       } else {
         console.log('Database is up to date.')


### PR DESCRIPTION
Päivitetty oikeuskäytännön lataamista tietokantaan:
- nyt tarkistetaan myös, että onko oikeuskäytännön taulu olemassa, ja mikä on viimeisin vuosi
- finlexistä noutamiseen lisätty virheenkäsittelyä ja gzip tuki

Ongelma, mikä jää tämän myötä voimaan:
- jos joku yksittäinen oikeuskäytäntö tai laki nouto palauttaa esim 500, niin se skipataan ja mennään seuraavaan.
- kunhan viimeisin vuosi saadaan kokonaan, niin dbIsUpToDate luulee että saatiin kaikki
- tämän kanssa jatkuu työ issuessa #80 