### PR TITLE
näytä tyhjät tulokset lopussa ja tagattuna

### DIFF
--- a/backend/src/app.ts
+++ b/backend/src/app.ts
@@ -49,7 +49,8 @@ async function getStatutesByYearAndLanguage(year: number, language: string) {
     return {
       docYear: result.year,
       docNumber: result.number,
-      docTitle: result.title
+      docTitle: result.title,
+      isEmpty: result.is_empty
     };
   });
   return preparedResults;
@@ -136,7 +137,8 @@ async function searchLawsByKeywordAndLanguage(keyword: string, language: string)
     return {
       docYear: result.year,
       docNumber: result.number,
-      docTitle: result.title
+      docTitle: result.title,
+      isEmpty: result.is_empty
     };
   });
   return preparedResults;
@@ -149,7 +151,8 @@ async function getJudgmentsByYearAndLanguageAndLevel(year: number, language: str
     return {
       docYear: result.year,
       docNumber: result.number,
-      docLevel: result.level
+      docLevel: result.level,
+      isEmpty: result.is_empty
     };
   });
   return preparedResults;
@@ -177,7 +180,8 @@ async function searchJudgmentsByKeywordAndLanguage(keyword: string, language: st
     return {
       docYear: result.year,
       docNumber: result.number,
-      docLevel: result.level
+      docLevel: result.level,
+      isEmpty: result.is_empty
     };
   });
   return preparedResults;

--- a/backend/src/db/akoma.ts
+++ b/backend/src/db/akoma.ts
@@ -8,15 +8,15 @@ async function getLawByNumberYear(number: string, year: number, language: string
   return result.rows[0]?.content || null;
 }
 
-async function getLawsByYear(year: number, language: string): Promise<{ title: string; number: string; year: number }[]> {
-  const sql = 'SELECT title, number, year FROM laws WHERE year = $1 AND language = $2';
+async function getLawsByYear(year: number, language: string): Promise<{ title: string; number: string; year: number, is_empty: boolean }[]> {
+  const sql = 'SELECT title, number, year, is_empty FROM laws WHERE year = $1 AND language = $2 ORDER BY is_empty ASC, number ASC';
   const result = await query(sql, [year, language]);
   return result.rows;
 }
 
-async function getLawsByContent(keyword: string, language: string): Promise<{ title: string; number: string; year: number }[]> {
+async function getLawsByContent(keyword: string, language: string): Promise<{ title: string; number: string; year: number, is_empty: boolean }[]> {
   const escapedKeyword = keyword.replaceAll('\'', '');
-  const sql = "SELECT title, number, year FROM laws WHERE language = $1 AND (title ILIKE $2 OR cardinality(xpath($3, content, ARRAY[ARRAY['akn', 'http://docs.oasis-open.org/legaldocml/ns/akn/3.0']])) > 0)";
+  const sql = "SELECT title, number, year, is_empty FROM laws WHERE language = $1 AND (title ILIKE $2 OR cardinality(xpath($3, content, ARRAY[ARRAY['akn', 'http://docs.oasis-open.org/legaldocml/ns/akn/3.0']])) > 0) ORDER BY is_empty ASC, year ASC, number ASC";
   const xpath_query = `//akn:p/text()[contains(., '${escapedKeyword}')]`;
   const result = await query(sql, [language, `%${escapedKeyword}%`, xpath_query]);
   return result.rows;
@@ -29,16 +29,16 @@ async function getJudgmentByNumberYear(number: string, year: number, language: s
   return result.rows[0]?.content || null;
 }
 
-async function getJudgmentsByYear(year: number, language: string, level: string): Promise<{ title: string; number: string; year: number, level: string }[]> {
+async function getJudgmentsByYear(year: number, language: string, level: string): Promise<{ title: string; number: string; year: number, level: string, is_empty: boolean }[]> {
   if (level === 'any') level = '%';
-  const sql = 'SELECT level, number, year FROM judgments WHERE year = $1 AND language = $2 AND level ILIKE $3';
+  const sql = 'SELECT level, number, year, is_empty FROM judgments WHERE year = $1 AND language = $2 AND level ILIKE $3 ORDER BY is_empty ASC, number ASC, level ASC';
   const result = await query(sql, [year, language, level]);
   return result.rows;
 }
 
-async function getJudgmentsByContent(keyword: string, language: string, level: string): Promise<{ title: string; number: string; year: number, level: string }[]> {
+async function getJudgmentsByContent(keyword: string, language: string, level: string): Promise<{ title: string; number: string; year: number, level: string, is_empty: boolean }[]> {
   if (level === 'any') level = '%';
-  const sql = 'SELECT number, level, year FROM judgments WHERE language = $1 AND level LIKE $2 AND content ILIKE $3'
+  const sql = 'SELECT number, level, year, is_empty FROM judgments WHERE language = $1 AND level LIKE $2 AND content ILIKE $3 ORDER BY is_empty ASC, number ASC, level ASC';
   const result = await query(sql, [language, level, `%${keyword}%`]);
   return result.rows;
 }

--- a/frontend/src/components/DocumentList.test.tsx
+++ b/frontend/src/components/DocumentList.test.tsx
@@ -17,7 +17,7 @@ test('renders content', () => {
         docTitle: 'Title2'
     },]
    
-    render(<DocumentList laws={laws} frontsection={"statute"} />)
+    render(<DocumentList laws={laws} frontsection={"statute"} language={"fin"}/>)
     const element = screen.getByText('123/2000 - Title')
     expect(element).toBeDefined()
     const element2 = screen.getByText('321/2000 - Title2')

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -2,7 +2,7 @@ import type {DocumentListProps, Document} from "../types"
 import {nanoid} from 'nanoid'
 
 
-const DocumentList = ({laws, frontsection}: DocumentListProps) => {
+const DocumentList = ({laws, frontsection, language}: DocumentListProps) => {
  
 
   const listStyle = {
@@ -41,11 +41,12 @@ const DocumentList = ({laws, frontsection}: DocumentListProps) => {
     return `${doc.docLevel ? doc.docLevel : ""}${doc.docYear}${doc.docNumber}${nanoid(2)}`;
   }
   
+  const emptyTagName = language === 'fin' ? 'Tyhjä': 'Tom'
   return (
     <>
     { laws.map((law) => 
         <div style={listStyle} key={prepareKey(law)} >
-          {law.isEmpty ? <span style={tagStyle}>Empty</span>: ""}
+          {law.isEmpty ? <span style={tagStyle}>{emptyTagName}</span>: ""}
           <a href={prepareLink(law)}>
             {prepareLabel(law)} {law.docTitle ? `- ${law.docTitle}` : ""}
           </a>

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -12,6 +12,18 @@ const DocumentList = ({laws, frontsection}: DocumentListProps) => {
     margin: '4px',
   }
 
+  const tagStyle = {
+    display: 'inline-block',
+    padding: '0.6em 0.6em',
+    'font-size': '0.9em',
+    color: '#721c24',
+    'background-color': '#f8d7da',
+    border: '1px solid #f5c6cb',
+    'border-radius': '0.25rem',
+    'line-height': 1,
+    'white-space': 'normal'
+  }
+
   function prepareLink(doc: Document): string {
     return `/${frontsection}/${doc.docYear}/${doc.docNumber}${doc.docLevel ? `/${doc.docLevel}` : ""}`;
   }
@@ -33,6 +45,7 @@ const DocumentList = ({laws, frontsection}: DocumentListProps) => {
     <>
     { laws.map((law) => 
         <div style={listStyle} key={prepareKey(law)} >
+          {law.isEmpty ? <span style={tagStyle}>Empty</span>: ""}
           <a href={prepareLink(law)}>
             {prepareLabel(law)} {law.docTitle ? `- ${law.docTitle}` : ""}
           </a>

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -1,5 +1,4 @@
 import type {DocumentListProps, Document} from "../types"
-import {nanoid} from 'nanoid'
 
 
 const DocumentList = ({laws, frontsection, language}: DocumentListProps) => {
@@ -38,7 +37,7 @@ const DocumentList = ({laws, frontsection, language}: DocumentListProps) => {
   }
 
   function prepareKey(doc: Document): string {
-    return `${doc.docLevel ? doc.docLevel : ""}${doc.docYear}${doc.docNumber}${nanoid(2)}`;
+    return `${doc.docLevel ? doc.docLevel : ""}${doc.docYear}${doc.docNumber}${language}`;
   }
   
   const emptyTagName = language === 'fin' ? 'Tyhjä': 'Tom'

--- a/frontend/src/components/DocumentList.tsx
+++ b/frontend/src/components/DocumentList.tsx
@@ -15,13 +15,13 @@ const DocumentList = ({laws, frontsection, language}: DocumentListProps) => {
   const tagStyle = {
     display: 'inline-block',
     padding: '0.6em 0.6em',
-    'font-size': '0.9em',
+    fontSize: '0.9em',
     color: '#721c24',
-    'background-color': '#f8d7da',
+    backgroundColor: '#f8d7da',
     border: '1px solid #f5c6cb',
-    'border-radius': '0.25rem',
-    'line-height': 1,
-    'white-space': 'normal'
+    borderRadius: '0.25rem',
+    lineHeight: 1,
+    whiteSpace: 'normal'
   }
 
   function prepareLink(doc: Document): string {

--- a/frontend/src/components/ListDocumentPage.tsx
+++ b/frontend/src/components/ListDocumentPage.tsx
@@ -1,7 +1,7 @@
 import axios from 'axios'
 import { useState } from 'react'
 import SearchForm from './SearchForm'
-import CaseLawList from './DocumentList'
+import DocumentList from './DocumentList'
 import Notification  from './Notification'
 import type {Document, ListDocumentPageProps} from '../types'
 import LanguageSelection from './LanguageSelection'
@@ -132,7 +132,7 @@ const ListDocumentPage = ({language, setLanguage, buttonetext, placeholdertext, 
                     <Notification message={errorMessage} />
                 </div>
    
-                <CaseLawList laws={laws} frontsection={frontsection} />
+                <DocumentList laws={laws} frontsection={frontsection} language={language} />
             </div>
         </div>
     </div>

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -16,6 +16,7 @@
   docNumber: string,
   docLevel?: string,
   docTitle?: string
+  isEmpty?: boolean,
 }
 
 export interface DocumentPageProps {

--- a/frontend/src/types.ts
+++ b/frontend/src/types.ts
@@ -38,7 +38,8 @@ export interface ListDocumentPageProps {
 
 export interface DocumentListProps {
   laws: Document[],
-  frontsection: string
+  frontsection: string,
+  language: string
 }
 
 export interface Props {


### PR DESCRIPTION
Järjestä tulokset siten, että tyhjät tulokset ovat lopussa.
Lisää tyhjiin tuloksiin tagi, joka visuaalisesti auttaa erottamaan ne.

close #96
close #97 
close #93 