### PR TITLE
toska hijack

### DIFF
--- a/.github/workflows/build_production.yml
+++ b/.github/workflows/build_production.yml
@@ -1,40 +1,30 @@
 name: Build and push docker image (production)
 
 on:
-  push:
-    branches:
-      - main
+  release:
+    types: [published]
 
 jobs:
-  build-and-push:
+  build-and-store:
     runs-on: ubuntu-latest
     steps:
-      -
-        name: Checkout
+      - name: Checkout
         uses: actions/checkout@v4
-      -
-        name: Build frontend
+      - name: Build frontend
         run: |
           npm --prefix ./frontend ci
           npm --prefix ./frontend run build
-      -
-        name: Build backend
+      - name: Build backend
         run: |
           npm --prefix ./backend ci
           npm --prefix ./backend run build
-      -
-        name: Login to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-      -
-        name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
-      -
-        name: Build and push
-        uses: docker/build-push-action@v6
+      - name: Build and and export
+        uses: redhat-actions/push-to-registry@v2
         with:
           context: .
-          push: true
-          tags: arttkan/finlex-lukija:production
+          image: ${{ steps.build-image.outputs.image }}
+          tags: ${{ steps.build-image.outputs.tags }}
+          registry: quay.io/toska
+          username: toska+github
+          password: ${{ secrets.QUAY_IO_TOKEN }}
+   


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow for building and publishing the production Docker image. The workflow now triggers on published releases instead of pushes to the `main` branch, and switches the Docker image registry from Docker Hub to Quay.io using a different action for image export.

Workflow trigger and registry migration:

* Changed the workflow trigger from `push` on the `main` branch to `release` events of type `published`, ensuring production images are only built and stored for official releases.
* Migrated the Docker image publishing from Docker Hub to Quay.io, updating authentication and registry details accordingly.
* Replaced the use of `docker/login-action`, `docker/setup-buildx-action`, and `docker/build-push-action` with the `redhat-actions/push-to-registry` action for building and exporting images.